### PR TITLE
SL-6161 - Use Java 11.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
   </properties>
 
   <licenses>


### PR DESCRIPTION
### Description of Changes

Using Java 11 instead of Java 17 so that this is compatible with `main`. We intend to update this repo to 17 soon, but we don't want releasing this package to be blocked on that. We can update back to Java 17 after that.

### Documentation
Not Applicable

### Risks & Impacts

### Testing
Ran `mvn clean install` locally.